### PR TITLE
Create developer-helper Python script for help managing PyLith development environment

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,8 @@ EXTRA_DIST = \
 	docker/ubuntu-18.04 \
 	docker/ubuntu-20.04 \
 	docker/ubuntu-21.04 \
-	developer/developer_helper.cfg \
+	developer/developer-helper.py \
+	developer/developer-helper.cfg \
 	packager/build.py \
 	packager/setup_darwin.sh \
 	packager/setup_linux64.sh \

--- a/bin/developer_helper.py
+++ b/bin/developer_helper.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Application for managing the PyLith build environment.
+"""
+
+import sys
+import os
+import argparse
+import subprocess
+import configparser
+
+
+class Package():
+    """Base class for software package.
+    """
+    NAME = None
+    CLONE_RECURSIVE = False
+
+    def __init__(self, config):
+        if not "base" in config:
+            raise ValueError(f"Configure missing base settings.")
+        self.base = config["base"]
+
+        if not self.NAME in config:
+            raise ValueError(f"Configure missing settings for '{self.NAME}'.")
+        self.config = config[self.NAME]
+
+        self.base["debug"] = self.base["debug"] == "True"
+        self.base["build_threads"] = int(self.base["build_threads"])
+        self.config["upstream"] = self.config["upstream"] if self.config["upstream"] != "False" else False
+
+    @staticmethod
+    def _display(lines):
+        print("\n".join(lines))
+
+    def _cd_src(self, top=False):
+        fullpath = os.path.join(self.base["src_dir"], self.NAME) if not top else self.base["src_dir"]
+        return [f"cd {fullpath}"]
+
+    def _cd_build(self):
+        build_arch = "debug" if self.base["debug"] else "opt"
+        fullpath = os.path.join(self.base["build_dir"], build_arch, self.NAME)
+        return [f"cd {fullpath}"]
+
+    def _git_current_branch(self):
+        """Get current git branch.
+        """
+        src_dir = self.base["src_dir"]
+        if not os.path.exists(src_dir):
+            return None
+        proc = subprocess.run("git branch", cwd=self.base["src_dir"])
+        lines = proc.stdout.splitlines()
+        for line in lines:
+            if line.startswith("* "):
+                branch = line[2:].strip()
+                return branch
+        return None
+
+    def configure(self):
+        lines = [f"# Configure '{self.NAME}''."]
+
+        lines += ["# Generate the configure script using autoreconf."]
+        lines += self._cd_src()
+        lines += ["autoreconf -if"]
+        lines += [""]
+
+        lines += ["# Run configure."]
+        lines += self._cd_build()
+        configure_fullpath = os.path.join(self.base["src_dir"], self.NAME, "configure")
+        lines += [f"{configure_fullpath} {self._configure_args()}"]
+        self._display(lines)
+
+    def build(self):
+        branch = self._git_current_branch()
+        lines = [f"# Build branch '{branch}' for '{self.NAME}'."]
+        lines += self._cd_build()
+        lines += [f"make install -j{self.base['build_threads']}"]
+        self._display(lines)
+    
+    def test(self):
+        lines = [f"# Test '{self.NAME}'."]
+        lines += self._cd_build()
+        lines += [f"make check -j{self.base['build_threads']}"]
+        self._display(lines)
+
+    def git_clone(self):
+        lines = [f"# Clone '{self.NAME}'."]
+        lines += self._cd_src(top=True)
+        cmd = "git clone "
+        if self.CLONE_RECURSIVE:
+            cmd += " --recursive"
+        if self.config["branch"] != "main":
+            cmd += f" --branch {self.config['branch']}"
+        cmd += " " + self.config["repo_url"]
+        lines += [cmd]
+        self._display(lines)
+    
+    def git_set_upstream(self):
+        if not self.config["upstream"]:
+            lines = [f"# No upstream repository for '{self.NAME}'."]
+        else:
+            lines = [f"# Set upstream repository for '{self.NAME}.'"]
+            lines += self._cd_src()
+            lines += ["git remote -v # Show current remote repositories."]
+            lines += [f"git remote add upstream {self.config['upstream']}"]
+            lines += ["git remote -v # Verify new upstream"]
+        self._display(lines)
+
+    def git_sync_fork(self, branch="main"):
+        if not self.config["upstream"]:
+            lines = [f"# No upstream repository for '{self.NAME}'."]
+        else:
+            lines = [f"# Synchronize local branch {branch} for '{self.NAME}.'"]
+            lines += self._cd_src()
+            lines += ["git fetch upstream"]
+            lines += [f"git checkout {branch}"]
+            lines += [f"git merge upstream/{branch}"]
+        self._display(lines)
+
+    def git_fetch(self):
+        lines = [f"# Update local clone for '{self.NAME}'."]
+        lines += self._cd_src()
+        lines += [f"git fetch -p"]
+        self._display(lines)
+        return
+
+    def git_set_branch(self, branch):
+        current_branch = self._git_current_branch()
+        lines = [f"# Change from branch '{current_branch}' to branch '{branch}' for '{self.NAME}'."]
+        lines += self._cd_src()
+        lines += [f"git checkout {branch}"]
+        self._display(lines)
+        return
+
+    def git_new_branch(self, branch):
+        current_branch = self._git_current_branch()
+        lines = [f"# Create new branch '{branch}' from branch '{current_branch}' for '{self.NAME}'."]
+        lines += self._cd_src()
+        lines += [f"git checkout -b {branch}"]
+        self._display(lines)
+        return
+
+    def git_delete_branch(self, branch):
+        lines = [f"# Delete local branch '{branch}' from '{self.NAME}'."]
+        lines += self._cd_src()
+        lines += [f"git branch -D {branch}"]
+        self._display(lines)
+        return
+
+    def git_rebase(self, ref_branch):
+        lines = [
+                "DANGER: Rebasing can lead to irreversible changes to your repository!!!",
+                "        Only rebase if you are sure you know what you are doing.",
+                "",
+                "TIP: You should always test your code _after_ rebasing and _before_ pushing to verify",
+                "     your changes.",
+                "",
+                "After successfully rebasing, DO NOT run 'git pull' as git will suggest.",
+                "Instead, run 'git push --force'",
+                "",
+                "If you encounter problems while rebasing, you can abort by running 'git rebase --abort'.",
+                "This will return the repository to the state it was in before rebasing.",
+                "",
+                ]
+        lines += [f"# Interactive rebase for '{self.NAME}'."]
+        lines += [f"git rebase -i {ref_branch}"]
+        self._display(lines)
+
+    def git_replace_branch(self, branch):
+        lines = [f"Delete and checkout branch '{branch}' for '{self.NAME}'."]
+        lines += [f"git checkout main && git delete -D {branch} && git checkout {branch}"]
+        self._display(lines)
+        return
+
+    def _configure_args(self):
+        return
+
+class Pythia(Package):
+    """Pythia package.
+    """
+    NAME = "pythia"
+    CLONE_RECURSIVE = True
+
+    def _configure_args(self):
+        args = [
+            f"--prefix={self.base['install_dir']}",
+            "--enable-testing",
+            "CC=mpicc",
+            "CXX=mpicxx",
+        ]
+        if self.base["debug"]:
+            args += [
+                "CFLAGS='-g -Wall'",
+                "CXXFLAGS='-g -Wall'",
+            ]
+        else:
+            args += [
+                "CFLAGS='-g -O3 -DNDEBUG'",
+                "CXXFLAGS='-g -O3 -DNDEBUG'",
+            ]
+        return " ".join(args)
+
+class Spatialdata(Package):
+    """Spatialdata package.
+    """
+    NAME = "spatialdata"
+    CLONE_RECURSIVE = True
+
+    def _configure_args(self):
+        args = [
+            f"--prefix={self.base['install_dir']}",
+            "--enable-swig",
+            "--enable-testing",
+            "CC=mpicc",
+            "CXX=mpicxx",
+            f"CPPFLAGS=\"-I{self.base['deps_dir']}/include -I{self.base['install_dir']}/include\"",
+            f"LDFLAGS=\"-L{self.base['deps_dir']}/lib -L{self.base['install_dir']}/lib\"",
+        ]
+        if self.base["debug"]:
+            args += [
+                "CFLAGS='-g -O0 -Wall'",
+                "CXXFLAGS='-g -O0 -Wall'",
+            ]
+        else:
+            args += [
+                "CFLAGS='-g -O3 -DNDEBUG'",
+                "CXXFLAGS='-g -O3 -DNDEBUG'",
+            ]
+        return " ".join(args)
+
+
+class Petsc(Package):
+    """Petsc package.
+    """
+    NAME = "petsc"
+    CLONE_RECURSIVE = False
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.petsc_arch = "arch-pylith-debug" if self.base["debug"] else "arch-pylith-opt"
+        self.petsc_dir = os.path.join(self.base["src_dir"], "petsc")
+
+    def configure(self):
+        lines = [f"# Configure '{self.NAME}''."]
+
+        lines += ["# Run configure."]
+        lines += self._cd_src()
+        lines += [f"python3 ./configure {self._configure_args()}"]
+        self._display(lines)
+
+    def build(self):
+        lines = [f"# Build '{self.NAME}'."]
+        lines += self._cd_src()
+        lines += [f"make -j{self.base['build_threads']} PETSC_DIR={self.petsc_dir} PETSC_ARCH={self.petsc_arch}"]
+        self._display(lines)
+    
+    def _configure_args(self):
+        args = [
+            "--with-c2html=0",
+            "--with-lgrind=0",
+            "--with-fc=0",
+            "--with-x=0",
+            "--with-clanguage=C",
+            "--with-mpicompilers=1",
+            "--with-shared-libraries=1",
+            "--with-64-bit-points=1",
+            "--with-large-file-io=1",
+            "--with-hdf5=1",
+            "--download-chaco=1",
+            "--download-ml=1",
+            "--download-f2cblaslapack=1",
+        ]
+        if self.base["debug"]:
+                args += [
+                "--with-debugging=1",
+                "CFLAGS='-g -O0 -Wall'",
+                ]
+        else:
+                args += [
+                "--with-debugging=0",
+                "CFLAGS='-g -O3 -DNDEBUG'",
+                ]
+        args += [
+            f"CPPFLAGS=\"-I$HDF5_INCDIR -I{self.base['deps_dir']}/include -I{self.base['install_dir']}/include\"",
+            f"LDFLAGS=\"-L$HDF5_LIBDIR -L{self.base['deps_dir']}/lib -L{self.base['install_dir']}/lib\"",
+            f"PETSC_DIR={self.petsc_dir}",
+            f"PETSC_ARCH={self.petsc_arch}",
+        ]
+        return " ".join(args)
+
+
+class PyLith(Package):
+    """PyLith package.
+    """
+    NAME = "pylith"
+    CLONE_RECURSIVE = True
+
+    def _configure_args(self):
+        args = [
+            f"--prefix={self.base['install_dir']}",
+            "--enable-cubit"
+            "--enable-hdf5",
+            "--enable-swig",
+            "--enable-testing",
+            "CC=mpicc",
+            "CXX=mpicxx",
+            f"CPPFLAGS=\"-I$HDF5_INCDIR -I{self.base['deps_dir']}/include -I{self.base['install_dir']}/include\"",
+            f"LDFLAGS=\"-L$HDF5_LIBDIR -L{self.base['deps_dir']}/lib -L{self.base['install_dir']}/lib\"",
+        ]
+        if self.base["debug"]:
+            args += [
+                "CFLAGS='-g -O0 -Wall'",
+                "CXXFLAGS='-g -O0 -Wall'",
+            ]
+        else:
+            args += [
+                "CFLAGS='-g -O3 -DNDEBUG'",
+                "CXXFLAGS='-g -O3 -DNDEBUG'",
+            ]
+        return " ".join(args)
+
+def create_package(name, config):
+    if name == "pythia":
+        return Pythia(config)
+    elif name == "spatialdata":
+        return Spatialdata(config)
+    elif name == "petsc":
+        return Petsc(config)
+    elif name == "pylith":
+        return PyLith(config)
+    else:
+        raise ValueError(f"Unknown package {name}.")
+
+
+class App():
+    """Main application.
+    """
+
+    def __init__(self):
+        """Constructor."""
+        self.config = None
+
+    def main(self):
+        """Main entry point.
+        """
+        args = self._parse_command_line()
+        self.initialize(args.config)
+
+        if args.show_config:
+            self.show_config()
+
+        package = create_package(args.package, self.config)
+        if args.git_clone:
+            package.git_clone()
+        if args.git_set_upstream:
+            package.git_set_upstream()
+        if args.git_sync_fork:
+            package.git_sync_fork()
+        if args.git_fetch:
+            package.git_fetch()
+        if args.git_set_branch:
+            package.git_set_branch(args.git_set_branch)
+        if args.git_new_branch:
+            package.git_new_branch(args.git_new_branch)
+        if args.git_delete_branch:
+            package.git_delete_branch(args.git_delete_branch)
+        if args.git_rebase:
+            package.git_rebase(args.git_rebase)
+        if args.git_replace_branch:
+            package.git_replace_branch(args.git_replace_branch)
+
+        if args.configure:
+            package.configure()
+        if args.build:
+            package.build()
+        if args.test:
+            package.test()
+
+    def initialize(self, filename, keep_case=True, verbose=False):
+        """Set parameters from config file.
+
+        Args:
+            filenames (list)
+                List of .cfg files to read.
+            keep_case (bool)
+                If True, maintain case in section headings, otherwise convert to lowercase.
+            verbose (bool)
+                If True, print out progress.
+
+        Returns:
+            Dictionary with configuration.
+        """
+        if not os.path.isfile(filename):
+            raise IOError(f"Could not find configuration file '{filename}'.")
+        if verbose:
+            print(f"Fetching parameters from {filename}...")
+        config = configparser.ConfigParser()
+        config.read(filename)
+        self.config = {s: dict(config.items(s)) for s in config.sections()}
+
+    def show_config(self):
+        """Write configuration to stdout.
+        """
+        parser = configparser.ConfigParser()
+        parser.read_dict(self.config)
+        parser.write(sys.stdout)
+
+    def _parse_command_line(self):
+        """Parse command line arguments.
+        """
+        DESCRIPTION = (
+            "Application for managing the PyLith development environment. "
+            "Once you become familiar with the build environment you will not need this utility."
+        )
+        PACKAGES = ["pythia", "spatialdata", "petsc", "pylith"]
+
+        parser = argparse.ArgumentParser(description=DESCRIPTION)
+        parser.add_argument("--config", action="store", dest="config", required=True)
+        parser.add_argument("--package", action="store", dest="package", choices=PACKAGES, required=True)
+
+        parser.add_argument("--git-clone", action="store_true", dest="git_clone")
+        parser.add_argument("--git-set-upstream", action="store_true", dest="git_set_upstream")
+        parser.add_argument("--git-sync-fork", action="store_true", dest="git_sync_fork")
+        parser.add_argument("--git-set-branch", action="store", dest="git_set_branch", metavar="BRANCH")
+        parser.add_argument("--git-new-branch", action="store", dest="git_new_branch", metavar="BRANCH")
+        parser.add_argument("--git-delete-branch", action="store", dest="git_delete_branch", metavar="BRANCH")
+        parser.add_argument("--git-fetch", action="store_true", dest="git_fetch")
+        parser.add_argument("--git-rebase", action="store", dest="git_rebase", metavar="REF_BRANCH")
+        parser.add_argument("--git-replace-branch", action="store", dest="git_replace_branch", metavar="BRANCH")
+
+        parser.add_argument("--configure", action="store_true", dest="configure")
+        parser.add_argument("--build", action="store_true", dest="build")
+        parser.add_argument("--test", action="store_true", dest="test")
+
+        parser.add_argument("--show-config", action="store_true", dest="show_config")
+        args = parser.parse_args()
+        return args
+
+
+if __name__ == "__main__":
+    App().main()
+
+
+# End of file

--- a/bin/developer_helper.py
+++ b/bin/developer_helper.py
@@ -67,6 +67,7 @@ class Package():
         lines += self._cd_build()
         configure_fullpath = os.path.join(self.base["src_dir"], self.NAME, "configure")
         lines += [f"{configure_fullpath} {self._configure_args()}"]
+        lines += ["# After running configure, use --build to see the command for building."]
         self._display(lines)
 
     def build(self):
@@ -74,6 +75,7 @@ class Package():
         lines = [f"# Build branch '{branch}' for '{self.NAME}'."]
         lines += self._cd_build()
         lines += [f"make install -j{self.base['build_threads']}"]
+        lines += ["# After building the software, use --test to see the command for testing."]
         self._display(lines)
     
     def test(self):
@@ -92,6 +94,12 @@ class Package():
             cmd += f" --branch {self.config['branch']}"
         cmd += " " + self.config["repo_url"]
         lines += [cmd]
+        lines += [""]
+        lines += ["# When you clone a forked repository, you need to fix the cloning of the m4 submodules."]
+        lines += ["git config submodule.m4.url https://github.com/geodynamics/autoconf_cig.git"]
+        lines += ["# Repeat for any other m4 submodules, for example `templates/friction/m4`"]
+        lines += [""]
+        lines += ["# After running git clone, use --configure to see how to configure."]
         self._display(lines)
     
     def git_set_upstream(self):
@@ -110,6 +118,7 @@ class Package():
             lines = [f"# No upstream repository for '{self.NAME}'."]
         else:
             lines = [f"# Synchronize local branch {branch} for '{self.NAME}.'"]
+            lines += ["# NOTE: You must have set the upstream repository. See --git-set-upstream."]
             lines += self._cd_src()
             lines += ["git fetch upstream"]
             lines += [f"git checkout {branch}"]

--- a/developer/developer_helper.cfg
+++ b/developer/developer_helper.cfg
@@ -1,0 +1,28 @@
+[base]
+src_dir = /opt/pylith/src
+build_dir = /opt/pylith/build
+install_dir = /opt/pylith/dest
+deps_dir = /opt/dependencies
+debug = True
+build_threads = 8
+
+[pythia]
+repo_url = https://github.com/geodynamics/pythia.git
+branch = main
+upstream = False
+
+[spatialdata]
+repo_url = https://github.com/spatialdata/spatialdata.git
+branch = main
+upstream = False
+
+[petsc]
+repo_url = https://gitlab.com/petsc/petsc.git
+branch = knepley/pylith
+upstream = False
+
+[pylith]
+repo_url = https://github.com/GITHUB_USERNAME/pylith.git
+upstream = https://github.com/geodynamics/pylith.git
+branch = main
+

--- a/developer/developer_helper.cfg
+++ b/developer/developer_helper.cfg
@@ -28,7 +28,7 @@ upstream = False
 branch = main
 
 [spatialdata]
-repo_url = https://github.com/spatialdata/spatialdata.git
+repo_url = https://github.com/geodynamics/spatialdata.git
 upstream = False
 branch = main
 

--- a/developer/developer_helper.cfg
+++ b/developer/developer_helper.cfg
@@ -1,28 +1,43 @@
+# Basic information
 [base]
+# top-level source directory.
 src_dir = /opt/pylith/src
+
+# top-level build directory.
 build_dir = /opt/pylith/build
+
+# Install directory.
 install_dir = /opt/pylith/dest
+
+# Directory containing dependencies installed by the PyLith installer utility.
 deps_dir = /opt/dependencies
+
+# Build with debugging flags?
 debug = True
+
+# Number of make threads to use when compiling source code.
 build_threads = 8
+
+# For each software package, we specify the URL of the repository to clone and default branch to use.
+# If the repository to clone is a fork, then we use `upstream` to specify the main repository.
+# We assume only the PyLith repository is a fork.
 
 [pythia]
 repo_url = https://github.com/geodynamics/pythia.git
-branch = main
 upstream = False
+branch = main
 
 [spatialdata]
 repo_url = https://github.com/spatialdata/spatialdata.git
-branch = main
 upstream = False
+branch = main
 
 [petsc]
 repo_url = https://gitlab.com/petsc/petsc.git
-branch = knepley/pylith
 upstream = False
+branch = knepley/pylith
 
 [pylith]
 repo_url = https://github.com/GITHUB_USERNAME/pylith.git
 upstream = https://github.com/geodynamics/pylith.git
 branch = main
-

--- a/docker/pylith-devenv
+++ b/docker/pylith-devenv
@@ -45,6 +45,8 @@ RUN apt-get update \
       less \
       uncrustify \
       gnupg2 \
+      ssh \
+      linux-tools-common \
       vim-common \
       vim-runtime \
       vim-nox
@@ -74,6 +76,8 @@ ENV  src_dir=/opt/pylith-installer/src  build_dir=/opt/pylith-installer/build
 RUN mkdir -p /opt/pylith-installer && mkdir -p ${build_dir}
 
 COPY --chown=pylith-dev:pylith-dev . ${src_dir}
+COPY --chown=pylith-dev:pylith-dev ./bin/developer_helper.py ./developer/developer_helper.cfg /opt/pylith-devenv/
+
 
 WORKDIR ${src_dir}
 RUN autoreconf --install --verbose --force

--- a/docker/pylith-devenv
+++ b/docker/pylith-devenv
@@ -76,7 +76,7 @@ ENV  src_dir=/opt/pylith-installer/src  build_dir=/opt/pylith-installer/build
 RUN mkdir -p /opt/pylith-installer && mkdir -p ${build_dir}
 
 COPY --chown=pylith-dev:pylith-dev . ${src_dir}
-COPY --chown=pylith-dev:pylith-dev ./bin/developer_helper.py ./developer/developer_helper.cfg /opt/pylith-devenv/
+COPY --chown=pylith-dev:pylith-dev ./developer/developer_helper.py ./developer/developer_helper.cfg /opt/pylith-devenv/
 
 
 WORKDIR ${src_dir}

--- a/docs/devenv/configs.md
+++ b/docs/devenv/configs.md
@@ -127,6 +127,11 @@ cd $PYLITH_DIR/build/debug
 make -j$(nproc) -C dependencies
 ```
 
+:::{tip}
+Starting at this step, you can use the `developer-helper.py` Python script (see {ref}`sec-developer-helper`) to show the exact commands to run.
+This script and the default configuration file are in the `developer` directory of the PyLith installer source.
+:::
+
 Next, we configure and build pythia and spatialdata.
 
 ```bash
@@ -145,7 +150,7 @@ Set the `PETSC_DIR` environment variable to the location of PETSc, and set the `
 You should add these to your `.bashrc` or `setup.sh` file.
 
 ```bash
-export PETSC_DIR=$PYLITH_DIR/build/debug/petsc/knepley-feature-petsc-fe
+export PETSC_DIR=$PYLITH_DIR/build/debug/petsc/knepley/pylith
 export PETSC_ARCH=arch-pylith-debug
 ```
 
@@ -219,6 +224,11 @@ cd $PYLITH_DIR/build/debug
 make -j$(nproc) -C dependencies
 ```
 
+:::{tip}
+Starting at this step, you can use the `developer-helper.py` Python script (see {ref}`sec-developer-helper`) to show the exact commands to run.
+This script and the default configuration file are in the `developer` directory of the PyLith installer source.
+:::
+
 Next, we configure and build pythia and spatialdata.
 
 ```bash
@@ -237,7 +247,7 @@ Set the `PETSC_DIR` environment variable to the location of PETSc, and set the `
 You should add these to your `.bashrc` or `setup.sh` file.
 
 ```bash
-export PETSC_DIR=$PYLITH_DIR/build/debug/petsc/knepley-feature-petsc-fe
+export PETSC_DIR=$PYLITH_DIR/build/debug/petsc/knepley/pylith
 export PETSC_ARCH=arch-pylith-debug
 ```
 

--- a/docs/devenv/dev-helper.md
+++ b/docs/devenv/dev-helper.md
@@ -45,7 +45,7 @@ upstream = False
 branch = main
 
 [spatialdata]
-repo_url = https://github.com/spatialdata/spatialdata.git
+repo_url = https://github.com/geodynamics/spatialdata.git
 upstream = False
 branch = main
 

--- a/docs/devenv/dev-helper.md
+++ b/docs/devenv/dev-helper.md
@@ -1,0 +1,106 @@
+(sec-developer-helper)=
+# Developer-helper utility
+
+The `developer_helper.py` Python script provides developers with a quick reference to commands related to managing the PyLith development environment created by the installer or with the PyLith Development Docker image.
+The script shows the commands to run for configuring and building pythia, spatialdata, PETSc, and PyLith and Git commands for keeping the local clones in sync with the upstream repositories.
+
+## Setup
+
+The `developer_helper.py` script requires a configuration file to specify locations of the source, build, and install directories as well as which repositories to use.
+The top-level source directory is where the source code for pythia, spatialdata, PETSc, and PyLith will be downloaded.
+PETSc is built in a subdirectory within the source tree.
+The top-level build directory will contain the builds for pythia, spatialdata, and PyLith.
+
+```{code-block} ini
+---
+caption: Example configuration file for the `developer_helper.py` Python script.
+---
+# Basic information
+[base]
+# top-level source directory.
+src_dir = /opt/pylith/src
+
+# top-level build directory.
+build_dir = /opt/pylith/build
+
+# Install directory.
+install_dir = /opt/pylith/dest
+
+# Directory containing dependencies installed by the PyLith installer utility.
+deps_dir = /opt/dependencies
+
+# Build with debugging flags?
+debug = True
+
+# Number of make threads to use when compiling source code.
+build_threads = 8
+
+# For each software package, we specify the URL of the repository to clone and default branch to use.
+# If the repository to clone is a fork, then we use `upstream` to specify the main repository.
+# We assume only the PyLith repository is a fork.
+
+[pythia]
+repo_url = https://github.com/geodynamics/pythia.git
+upstream = False
+branch = main
+
+[spatialdata]
+repo_url = https://github.com/spatialdata/spatialdata.git
+upstream = False
+branch = main
+
+[petsc]
+repo_url = https://gitlab.com/petsc/petsc.git
+upstream = False
+branch = knepley/pylith
+
+[pylith]
+repo_url = https://github.com/GITHUB_USERNAME/pylith.git
+upstream = https://github.com/geodynamics/pylith.git
+branch = main
+```
+
+## Running `developer-helper.py`
+
+The script will print commands to run in a terminal shell based on the specified configuration and command line arguments.
+
+### Required command line arguments
+
+* **`--config=FILENAME`** Get the configuration settings from file `FILENAME`.
+* **`--package=PACKAGE`** Get help related to software package `PACKAGE`, where `PACKAGE` is one of `pythia`, `spatialdata`, `petsc`, and `pylith`.
+
+### Optional command line arguments
+
+The optional command line arguments correspond to tasks that the user wants to run.
+
+* **`--git-clone`** How to clone (download) the repository.
+* **`--git-set-upstream`** How to set the origin for a forked repository (where updates will come from and where pull requests should be made).
+* **`--git-sync-fork`** Steps for updating the main branch in a fork with the current upstream repository.
+* **`--git-set-branch`** How to set the current branch.
+* **`--git-new-branch`** How to create a new branch from the current branch.
+* **`--git-delete-branch`** How to delete a branch from the local clone.
+* **`--git-fetch`** How to fetch from the repository while pruning deleted branches.
+* **`--git-rebase`** Basic instructions for rebasing.
+* **`--git-replace-branch`** How to replace a local branch after it has been force pushed from another clone.
+* **`--configure`** How to run `configure` for the software package.
+* **`--build`** Command to run to build the software package.
+* **`--test`** Command to run to test the software package.
+* **`show-config`** Show the configuration file.
+
+### Order of commands for installing the software
+
+The software packages should be installed in the following order:
+
+1. pythia
+2. spatialdata
+3. PETSc
+4. PyLith
+
+When installing each package, the commands should be run in the following order:
+
+1. `--git-clone`
+2. `--configure`
+3. `--build`
+4. `--test`
+
+The remaining commands are used to update the software.

--- a/docs/devenv/docker-devenv.md
+++ b/docs/devenv/docker-devenv.md
@@ -54,8 +54,8 @@ You only need to run these setup steps once.
 
 2. Fork the following repositories:
 
-* <https://github.com/geodynamics/pythia>
-* <https://github.com/geodynamics/spatialdata>
+* <https://github.com/geodynamics/pythia> (optional, not recommended)
+* <https://github.com/geodynamics/spatialdata> (optional, not recommended)
 * <https://github.com/geodynamics/pylith>
 
 This creates copies of the repositories in your GitHub account.
@@ -135,13 +135,62 @@ mkdir -p ${INSTALL_DIR}
 This creates a local copy of the repositories in the persistent storage volume of the PyLith development container.
 These are your working copies of the repositories.
 
+:::{tip}
+Starting at this step, you can use the `developer-helper.py` Python script (see {ref}`sec-developer-helper`) to show the exact commands to run.
+This script and the default configuration file are in the `/opt/pylith-devenv` directory.
+:::
+
 ```bash
 cd /opt/pylith/src
-git clone --recursive https://github.com/GITHUB_USERNAME/pythia.git
-git clone --recursive https://github.com/GITHUB_USERNAME/spatialdata.git
+git clone --recursive https://github.com/geodynamics/pythia.git
+git clone --recursive https://github.com/geodynamics/spatialdata.git
 git clone --recursive https://github.com/GITHUB_USERNAME/pylith.git
 git clone --branch knepley/pylith https://gitlab.com/petsc/petsc.git
 ```
+
+#### Set the upstream repository
+
+For the PyLith repository and any other repositories that you forked, you should set the upstream repository.
+The upstream repository is the central, community repository from which you will get updates.
+
+```bash
+# PyLith repository (repeat for other repositories you forked)
+cd /opt/pylith/src/pylith
+git remote add upstream https://github.com/geodynamics/pylith.git
+```
+
+(sec-developer-fork-fix-m4-url)=
+#### Fixing path to m4 submodule
+
+For any of the repositories that you forked, you will encounter an error when it tries to clone the `m4` submodule, which has a relative link.
+The error message will be similar to:
+
+```bash
+Cloning into '/opt/pylith/src/pylith/m4'...
+remote: Repository not found.
+fatal: repository 'https://github.com/GITHUB_USERNAME/autoconf_cig.git/' not found
+fatal: clone of 'https://github.com/GITHUB_USERNAME/autoconf_cig.git' into submodule path '/opt/pylith/src/pylith/m4' failed
+Failed to clone 'm4'. Retry scheduled
+```
+
+The best workaround is to redirect your local clone to the geodynamics repository.
+You only need to do this once after cloning.
+
+```bash
+# Set URLs for submodules in `.git/config` to geodynamics repository (PyLith repository).
+cd /opt/pylith/src/pylith
+git config submodule.m4.url https://github.com/geodynamics/autoconf_cig.git
+git config submodule.templates/friction/m4.url https://github.com/geodynamics/autoconf_cig.git
+git config submodule.templates/materials/m4.url https://github.com/geodynamics/autoconf_cig.git
+
+# Update submodules
+git submodule update
+```
+
+:::{note}
+We use a relative link so that the GitLab mirror works correctly in our GitLab CI test runners.
+The consequence of using a relative link is that your local clone will look for a corresponding fork of the `autoconf_cig` repository.
+:::
 
 ### Configure and build PyLith for development
 

--- a/docs/devenv/index.md
+++ b/docs/devenv/index.md
@@ -6,4 +6,5 @@ maxdepth: 2
 ---
 configs.md
 docker-devenv.md
+dev-helper.md
 ```


### PR DESCRIPTION
Create `developer/developer-helper.py` to show what commands to run to configure, build, and install pythia, spatialdata, PETSc, and PyLith. Script also gives info on common, but more complex git commands.

Closes #8 