### PR TITLE
FIX: Update configure to detect OS and add --disable-libxml2 if on Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -527,6 +527,7 @@ AC_SUBST(petsc_git)
 # ----------------------------------------------------------------------
 # CHECK COMPATIBILITY OF OPTIONS
 # ----------------------------------------------------------------------
+AC_CANONICAL_HOST
 
 AC_PROG_CC
 AC_PROG_CPP
@@ -783,6 +784,19 @@ AC_SUBST(NETCDF_INCDIR)
 AC_SUBST(NETCDF_LIBDIR)
 AC_SUBST(NETCDF_INCLUDES)
 AC_SUBST(NETCDF_LDFLAGS)
+case $host_os in
+  darwin*)
+    NETCDF_OPTIONS=""
+    ;;
+  linux*)
+    NETCDF_OPTIONS="--disable-libxml2"
+    ;;
+  *)
+    NETCDF_OPTIONS=""
+  ;;
+esac
+AC_SUBST(NETCDF_OPTIONS)
+
 
 # NETCDF4 (python)
 if test "$install_netcdfpy" = yes ; then
@@ -939,7 +953,6 @@ fi
 
 
 # ----------------------------------------------------------------------
-AC_CANONICAL_HOST
 # Setup environment so dependencies are used in build
 CPPFLAGS="-I$prefix/include $CPPFLAGS"
 

--- a/dependencies/Makefile.am
+++ b/dependencies/Makefile.am
@@ -610,7 +610,7 @@ if INSTALL_NETCDF
 		../netcdf-c-$(NETCDF_VER)/configure --prefix=$(prefix) \
 			$(env_flags_deps) $(env_mpicompilers) \
 			CPPFLAGS="$(CPPFLAGS) $(HDF5_INCLUDES)" LDFLAGS="$(LDFLAGS) $(HDF5_LDFLAGS)" \
-			--enable-shared --disable-static --enable-netcdf-4 --disable-dap ; \
+			--enable-shared --disable-static --enable-netcdf-4 --disable-dap4 $(NETCDF_OPTIONS) ; \
 		sed -e "s/-l //g" libtool > libtool.tmp && mv -f libtool.tmp libtool; \
 		$(MAKE) -j $(make_threads) && \
 		$(MAKE) install && \


### PR DESCRIPTION
The NetCDF configure script checks for libxml2 even if dap4 and libxml2 are disabled. The workaround is to disable dap4 but not libxml2 on macOS while disabling libxml2 on Linux.